### PR TITLE
Fixed deprecated np.bool

### DIFF
--- a/cfar_filters/detector.py
+++ b/cfar_filters/detector.py
@@ -87,7 +87,7 @@ def run(image, mask, detector='gamma', method='AND', pfa=1e-9, enl=10.7, minsize
     # check datatypes are correct
     if (not isinstance(image, np.ndarray)) | (image.dtype != np.float32):
         raise TypeError(f'Input image must be of type np.ndarray(float32) but is of type {type(image)}, {image.dtype}')
-    if (not isinstance(mask, np.ndarray)) | (mask.dtype != np.bool):
+    if (not isinstance(mask, np.ndarray)) | (mask.dtype != bool):
         raise TypeError(f'Input mask must be of type np.ndarray(bool) but is of type {type(mask)}, {mask.dtype}')
 
     # check dimensions of image

--- a/cfar_filters/kdistribution.py
+++ b/cfar_filters/kdistribution.py
@@ -90,7 +90,7 @@ def detector(image, mask=0, N=40, pfa=1e-12, enl=10, wi=9, wo=15):
     # check if shapes are correct
     if len(image.shape) != 2:
         raise ValueError(f'Input image must be of shape [X, Y] but is of shape {image.shape}')
-    if (not isinstance(mask, np.ndarray)) | (mask.dtype != np.bool):
+    if (not isinstance(mask, np.ndarray)) | (mask.dtype != bool):
         raise TypeError(f'Input mask must be of type np.ndarray(bool) but is of type {type(mask)}, {mask.dtype}')
     if image.shape != mask.shape:
         raise ValueError((f'Shape of mask must match shape of image. \


### PR DESCRIPTION
A simple fix to the following error:

AttributeError: module 'numpy' has no attribute 'bool'. `np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here. The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

As seen above, np.bool is deprecated past NumPy 1.20